### PR TITLE
Fix ACP Client Concurrency and Error Handling

### DIFF
--- a/cmd/echo-agent/main.go
+++ b/cmd/echo-agent/main.go
@@ -56,7 +56,11 @@ func sendResponse(id interface{}, result interface{}) {
 		Result:  result,
 	}
 
-	data, _ := json.Marshal(resp)
+	data, err := json.Marshal(resp)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to marshal response: %v\n", err)
+		return
+	}
 	fmt.Println(string(data))
 }
 
@@ -70,6 +74,10 @@ func sendError(id interface{}, code int, message string) {
 		},
 	}
 
-	data, _ := json.Marshal(resp)
+	data, err := json.Marshal(resp)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to marshal error response: %v\n", err)
+		return
+	}
 	fmt.Println(string(data))
 }


### PR DESCRIPTION
## Summary
Addresses CodeRabbit review feedback on PR #16 - fixes critical concurrency bug and silent error handling issues.

## Changes

### 1. Concurrency Fix (pkg/acp/client.go)

**Problem:** Multiple goroutines calling `SendMessage()` concurrently could interleave:
- Goroutine A writes request 1, Goroutine B writes request 2
- Response 2 arrives first, consumed by Goroutine A 
- Goroutine B hangs waiting for response 1 that will never be matched

**Solution:**
- Replace separate `mu` mutex with `reqMu` that protects entire request/response cycle
- Hold lock from request write through response read
- Simplify `readResponse()` - no longer needs its own locks

**Before:**
```go
c.mu.Lock()
c.stdin.Write(data)  // Protected
c.mu.Unlock()
// GAP - another goroutine can write here!
c.readResponse()     // Race condition
```

**After:**
```go
c.reqMu.Lock()
defer c.reqMu.Unlock()
c.stdin.Write(data)
c.readResponse()  // Atomically paired with request
```

### 2. Error Handling Fix (cmd/echo-agent/main.go)

**Problem:** `json.Marshal()` errors silently ignored with `_` operator

**Solution:**
- Check marshal errors explicitly
- Log failures to stderr
- Return early to prevent sending malformed JSON

## Testing

✅ All unit tests pass
✅ Integration test passes (test-acp-client.go)
✅ Concurrent message test validates thread safety

## Impact

- **Critical**: Fixes data race that could cause deadlocks in production
- **Minor**: Improves debugging when JSON marshaling fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)