### PR TITLE
fix: Replace string error comparison with type assertions in test helpers

### DIFF
--- a/tests/e2e/helpers/process.go
+++ b/tests/e2e/helpers/process.go
@@ -125,13 +125,21 @@ func (s *RelayServer) Stop() error {
 		case err := <-done:
 			// Process exited
 			if err != nil {
-				// Check if process was killed by signal (expected when we call Kill())
+				// Check if process exited with an expected exit code
+				// Exit code 0: graceful shutdown (via context cancellation)
+				// Exit code -1: killed by signal (SIGKILL)
 				var exitErr *exec.ExitError
-				if !errors.As(err, &exitErr) || exitErr.ExitCode() != -1 {
-					// Not an exit error, or exited with non-zero code (not killed by signal)
+				if errors.As(err, &exitErr) {
+					code := exitErr.ExitCode()
+					if code != 0 && code != -1 {
+						// Exited with non-zero, non-signal code - this is an error
+						return fmt.Errorf("relay process exited with error code %d: %w", code, err)
+					}
+					// Exit code is 0 (graceful) or -1 (killed by signal) - both are expected
+				} else {
+					// Not an ExitError - treat as unexpected error
 					return fmt.Errorf("relay process exited with error: %w", err)
 				}
-				// Exit code is -1, which means killed by signal - this is expected
 			}
 			return nil
 		}


### PR DESCRIPTION
## Summary

Fixes #70 by replacing fragile string comparison with proper error type assertions in `RelayServer.Stop()`.

## Changes

### Before
```go
if err != nil && err.Error() != "signal: killed" {
    return fmt.Errorf("relay process exited with error: %w", err)
}
```

### After
```go
if err != nil {
    var exitErr *exec.ExitError
    if !errors.As(err, &exitErr) || exitErr.ExitCode() != -1 {
        return fmt.Errorf("relay process exited with error: %w", err)
    }
}
```

## Benefits

- **More robust**: Won't break if Go error messages change
- **Cross-platform**: Works consistently across different platforms
- **Clearer intent**: Explicitly checks exit status, not error text
- **Type-safe**: Uses proper error type checking

## How It Works

When a process is killed by a signal (like SIGKILL), `cmd.Wait()` returns an `*exec.ExitError` with `ExitCode()` returning `-1`. This is the standard way to detect signal termination in Go.

The fix properly handles:
1. Normal exit (no error)
2. Signal termination (exit code -1) - expected when we call `Kill()`
3. Error exit (non-zero exit code) - actual failures

## Testing

- ✅ `make lint` passes
- ✅ `make build` passes
- ✅ `make test` passes
- ✅ All existing tests continue to work

## Related

- Addresses PR #68 review feedback
- Part of Milestone 1: Foundation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved process termination handling in the test helpers. Exit codes are now interpreted to distinguish graceful shutdowns, signal-based kills, and unexpected failures, reducing false negatives. Updated logic yields clearer, more reliable test outcomes during process shutdown scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->