### PR TITLE
refactor: extract E2E test timeout to E2E_TEST_TIMEOUT environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-e2e:
 		echo "Please set your API key: export ANTHROPIC_API_KEY='your-key'"; \
 		exit 1; \
 	fi
-	@cd tests/e2e && go test -v -timeout 10m .
+	@cd tests/e2e && go test -v -timeout $${E2E_TEST_TIMEOUT:-10m} .
 
 # Run interactive demo showcasing PR #27 features
 demo:

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -134,7 +134,7 @@ fi
 # Using | cat forces line-buffered output instead of block-buffered
 cd "$PROJECT_ROOT"
 # shellcheck disable=SC2086
-if go test $TEST_FLAGS -timeout 10m ./tests/e2e/... 2>&1 | cat; then
+if go test $TEST_FLAGS -timeout ${E2E_TEST_TIMEOUT:-10m} ./tests/e2e/... 2>&1 | cat; then
     echo ""
     log_success "E2E tests passed!"
     exit 0


### PR DESCRIPTION
## Summary
Eliminates hardcoded timeout duplication between `Makefile:43` and `scripts/run-e2e.sh:137` by using the `E2E_TEST_TIMEOUT` environment variable with a fallback default.

## Changes
- **Makefile:43**: Replace `-timeout 10m` with `-timeout ${E2E_TEST_TIMEOUT:-10m}`
- **scripts/run-e2e.sh:137**: Replace `-timeout 10m` with `-timeout ${E2E_TEST_TIMEOUT:-10m}`

## Behavior
- **Default**: Uses `10m` if `E2E_TEST_TIMEOUT` is not set (maintains current behavior)
- **Override**: Users/CI can set `export E2E_TEST_TIMEOUT=15m` to change timeout globally
- **Single source of truth**: The environment variable name is the constant

## Testing
- ✅ Shell script syntax validated
- ✅ Makefile syntax validated (dry run)
- ✅ Variable expansion tested (default and override cases)
- ✅ All pre-commit checks passed

## Backward Compatibility
Fully compatible - behaves identically unless user explicitly overrides via environment variable.

Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * E2E tests now support configurable timeout settings via environment variables. The timeout defaults to 10 minutes if not specified, allowing teams to adjust test execution times based on their specific requirements and environments without code modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->