### PR TITLE
fix: prevent container creation in host mode

### DIFF
--- a/pkg/relay/session/manager.go
+++ b/pkg/relay/session/manager.go
@@ -435,25 +435,27 @@ func (m *Manager) TerminateAgent(ctx context.Context, userSessionID, agentID str
 
 	m.logger.Printf("[SESSION] Terminating agent: session=%s agentID=%s", userSessionID, agentID)
 
-	// NEW: Stop container if launcher exists
-	key := launcherKey(userSessionID, agentID)
-	m.launchersMu.RLock()
-	launcher := m.launchers[key]
-	handle := m.handles[key]
-	m.launchersMu.RUnlock()
+	// Stop container if launcher exists (container mode only)
+	if m.launcherFactory != nil && runtime.IsContainerMode() {
+		key := launcherKey(userSessionID, agentID)
+		m.launchersMu.RLock()
+		launcher := m.launchers[key]
+		handle := m.handles[key]
+		m.launchersMu.RUnlock()
 
-	if launcher != nil && handle != nil {
-		if err := launcher.Stop(ctx, handle); err != nil {
-			m.logger.Printf("WARN: Failed to stop container for agent %s: %v", agentID, err)
-			// Continue cleanup despite error
+		if launcher != nil && handle != nil {
+			if err := launcher.Stop(ctx, handle); err != nil {
+				m.logger.Printf("WARN: Failed to stop container for agent %s: %v", agentID, err)
+				// Continue cleanup despite error
+			}
 		}
-	}
 
-	// NEW: Remove from launcher maps
-	m.launchersMu.Lock()
-	delete(m.launchers, key)
-	delete(m.handles, key)
-	m.launchersMu.Unlock()
+		// Remove from launcher maps
+		m.launchersMu.Lock()
+		delete(m.launchers, key)
+		delete(m.handles, key)
+		m.launchersMu.Unlock()
+	}
 
 	// Close ACP client if present (with double-close protection)
 	agent.mu.Lock()
@@ -559,8 +561,8 @@ func (m *Manager) TerminateUserSession(ctx context.Context, userSessionID string
 					}
 				}
 
-				// NEW: Stop container if launcher exists
-				if m.launcherFactory != nil {
+				// Stop container if launcher exists (container mode only)
+				if m.launcherFactory != nil && runtime.IsContainerMode() {
 					key := launcherKey(userSessionID, id)
 					m.launchersMu.RLock()
 					launcher := m.launchers[key]


### PR DESCRIPTION
## Summary

Fixes bug where containers were being created even in host mode (default). The session manager was unconditionally creating container launchers when `launcherFactory` was available, regardless of the `OUROCODUS_ACP_RUNTIME` setting.

## Problem

When running the relay in host mode:
```bash
OUROCODUS_ACP_BINARY=$(pwd)/bin/echo-agent ./bin/relay
```

The logs showed:
```
[SESSION] ├─ Runtime mode: HOST (ACP will run directly on host)
[CONTAINER] Session created: id=1ccb1fc5... container=6edcebc6dc21...
```

This was contradictory - host mode should NOT create any containers.

## Root Cause

In `pkg/relay/session/manager.go:250`, the code checked:
```go
if m.launcherFactory != nil {
    // Always creates container launcher
```

The runtime mode check only affected which command was passed to the container, not whether a container was created at all.

## Solution

Changed the condition to:
```go
if m.launcherFactory != nil && runtime.IsContainerMode() {
    // Only creates container in container mode
```

Now:
- **Host mode** (default): Skips container creation entirely, spawns ACP directly via `os/exec`
- **Container mode**: Creates and attaches to container as before

## Test Plan

- ✅ All unit tests pass
- ✅ All TypeScript tests pass
- ✅ Build succeeds
- Tested manually: `make build && OUROCODUS_ACP_BINARY=$(pwd)/bin/echo-agent ./bin/relay`
  - Confirmed no container creation logs in host mode
  - Confirmed ACP spawns directly on host

## Changes

- Modified `(*Manager).SpawnAgent` to gate container creation by runtime mode
- Simplified logging to clearly distinguish host vs container modes
- Removed redundant container command logging in host mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Agent spawning and lifecycle now cleanly distinguishes container vs host runtime: container mode uses a launcher, host mode runs directly on the host.
  * Cleanup and termination only perform container-specific stop/teardown when container mode is active.
  * Improved logging and error handling during agent creation, with mode-aware resource tracking and conditional cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->