### PR TITLE
fix: add thread-safety and cleanup logging to worktree manager

### DIFF
--- a/pkg/worktree/manager.go
+++ b/pkg/worktree/manager.go
@@ -219,9 +219,9 @@ func (m *AgentWorktreeManager) cleanupStaleWorktree(ctx context.Context, worktre
 	}
 
 	// Directory exists - try to remove it from git's worktree tracking
-	// This uses the existing Remove method which handles all cleanup
-	if err := m.Remove(ctx, worktreePath); err != nil {
-		// If Remove fails, try manual cleanup
+	// Call removeUnlocked since Create() already holds the mutex
+	if err := m.removeUnlocked(ctx, worktreePath); err != nil {
+		// If removeUnlocked fails, try manual cleanup
 		// This can happen if git doesn't know about the directory
 		if err := os.RemoveAll(worktreePath); err != nil {
 			return fmt.Errorf("failed to remove stale directory: %w", err)
@@ -229,7 +229,7 @@ func (m *AgentWorktreeManager) cleanupStaleWorktree(ctx context.Context, worktre
 	}
 
 	// Verify directory was actually removed (defensive check)
-	// Even if Remove() succeeded, ensure the directory is gone
+	// Even if removeUnlocked() succeeded, ensure the directory is gone
 	if _, err := os.Stat(worktreePath); err == nil {
 		// Directory still exists, force removal
 		if err := os.RemoveAll(worktreePath); err != nil {
@@ -263,6 +263,12 @@ func (m *AgentWorktreeManager) Remove(ctx context.Context, worktreePath string) 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.removeUnlocked(ctx, worktreePath)
+}
+
+// removeUnlocked is the internal implementation of Remove without locking.
+// Callers must hold m.mu.
+func (m *AgentWorktreeManager) removeUnlocked(ctx context.Context, worktreePath string) error {
 	// Validate worktree path for safety
 	if err := validateWorktreePath(worktreePath); err != nil {
 		return err


### PR DESCRIPTION
## Summary

Fixes two related worktree manager issues:
- **#235** - Thread-safety violation risking git repository corruption under concurrent access
- **#239** - Silent branch cleanup failures leaving orphaned `agent-*` branches

## Changes

### Thread-Safety (#235)
- Added `sync.Mutex` field to `AgentWorktreeManager` struct
- Protected `Create()` method with `Lock/Unlock`
- Protected `Remove()` method with `Lock/Unlock`
- Updated struct documentation to describe blocking behavior

### Branch Cleanup Logging (#239)
- Modified `removeBranch()` to log errors instead of silently ignoring them
- Added `log` import for error logging
- Changed function documentation from "Best effort - does not return errors" to "Best effort - logs errors but does not fail"

## Testing

All tests pass with race detector enabled:
```bash
go test -race ./pkg/worktree/...
# ok  	github.com/2389-research/ourocodus/pkg/worktree	2.626s
```

All tests pass:
```bash
go test ./...
# All packages pass
```

Build succeeds:
```bash
make build
# Build complete. Binaries in bin/
```

Linter passes:
```bash
make lint
# No issues
```

## Impact

### #235 - Thread-Safety
- **Before**: Concurrent `Create()` or `Remove()` calls could corrupt git repository state
- **After**: Mutex serializes operations, preventing corruption
- **Performance**: Negligible impact - git operations are I/O bound (50-200ms), mutex acquisition is <1µs

### #239 - Branch Cleanup
- **Before**: Branch deletion failures were silently ignored, leading to orphaned branches
- **After**: Failures are logged with `[WARN]` prefix, making it easier to track cleanup issues
- **Behavior**: Still best-effort (doesn't fail the operation), but now observable

## Risk Assessment

- **Risk Level**: LOW
- **Backward Compatibility**: Full (no API changes)
- **Call Site Changes**: None required
- **Performance Impact**: Negligible

## Design Document

See [docs/plans/2025-11-14-worktree-thread-safety.md](../blob/fix/worktree-thread-safety-and-cleanup/docs/plans/2025-11-14-worktree-thread-safety.md) for detailed analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of worktree creation and removal with safer, serialized operations to prevent race conditions.
  * More robust cleanup of stale worktrees with additional fallbacks to ensure directories are removed.
  * Enhanced error reporting and logging for removal, pruning, and creation failures to aid troubleshooting and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->