### PR TITLE
fix: auto-recover from stale worktree registrations

### DIFF
--- a/docs/plans/2025-01-14-worktree-recovery-and-log-redaction-design.md
+++ b/docs/plans/2025-01-14-worktree-recovery-and-log-redaction-design.md
@@ -14,7 +14,7 @@ This design addresses two relay service improvements: automatic recovery from st
 
 When users manually delete worktree directories without running `git worktree remove`, Git retains stale registrations. Subsequent agent spawns fail with:
 
-```
+```text
 fatal: '/path/to/workspaces/agent-echo' is a missing but already registered worktree;
 use 'add -f' to override, or 'prune' or 'remove' to clear
 ```

--- a/pkg/worktree/manager.go
+++ b/pkg/worktree/manager.go
@@ -199,19 +199,31 @@ func (m *AgentWorktreeManager) Create(ctx context.Context, agentID, baseDir stri
 		if strings.Contains(stderrStr, "already registered") {
 			// Last resort: prune all stale worktrees and retry once
 			log.Printf("[WARN] Worktree already registered after cleanup, pruning all stale worktrees")
+			// #nosec G204 -- git command with validated repository path
 			pruneCmd := exec.CommandContext(ctx, "git", "worktree", "prune", "--verbose")
 			pruneCmd.Dir = m.repoPath
-			if pruneErr := pruneCmd.Run(); pruneErr != nil {
-				log.Printf("[WARN] Failed to prune worktrees: %v", pruneErr)
+			var pruneOutput bytes.Buffer
+			pruneCmd.Stdout = &pruneOutput
+			pruneCmd.Stderr = &pruneOutput
+			pruneErr := pruneCmd.Run()
+			if pruneErr != nil {
+				log.Printf("[WARN] Failed to prune worktrees: %v (output: %s)", pruneErr, pruneOutput.String())
+			} else {
+				log.Printf("[INFO] Prune output: %s", pruneOutput.String())
 			}
 
 			// Retry worktree creation once
-			retryCmd := exec.CommandContext(ctx, "git", "worktree", "add", "-b", branchName, worktreePath) // nolint:gosec // G204: branchName validated by git command itself
+			// #nosec G204 -- git command with validated arguments
+			retryCmd := exec.CommandContext(ctx, "git", "worktree", "add", "-b", branchName, worktreePath)
 			retryCmd.Dir = m.repoPath
 			var retryStderr bytes.Buffer
 			retryCmd.Stderr = &retryStderr
 			if retryErr := retryCmd.Run(); retryErr != nil {
-				return nil, fmt.Errorf("failed to create worktree after prune: %w (stderr: %s)", retryErr, retryStderr.String())
+				pruneStatus := "succeeded"
+				if pruneErr != nil {
+					pruneStatus = fmt.Sprintf("failed: %v", pruneErr)
+				}
+				return nil, fmt.Errorf("failed to create worktree after prune (prune %s): %w (stderr: %s)", pruneStatus, retryErr, retryStderr.String())
 			}
 			log.Printf("[INFO] Successfully created worktree after prune recovery")
 		} else {


### PR DESCRIPTION
## Summary
Implements automatic recovery from stale Git worktree registrations (#192).

## Problem
When users manually delete worktree directories without running `git worktree remove`, Git retains stale registrations. Subsequent agent spawns fail with:

```
fatal: '/path/to/workspaces/agent-echo' is a missing but already registered worktree;
use 'add -f' to override, or 'prune' or 'remove' to clear
```

This forces users to manually run `git worktree prune` before spawning can succeed.

## Solution
Add automatic recovery in the `Create` method:

1. Existing `cleanupStaleWorktree` attempts `git worktree remove --force`
2. **NEW**: If worktree creation still fails with "already registered":
   - Run `git worktree prune --verbose` to clean all stale entries
   - Retry worktree creation once
   - Log warnings and success messages for debugging

## Changes
- Modified `pkg/worktree/manager.go` Create method
- Added detection for "already registered" error
- Added automatic prune + retry recovery flow
- Added logging for recovery operations

## Testing
- ✅ All existing worktree tests pass
- ✅ Full test suite passes (14 packages)
- ✅ Manual testing scenario:
  1. Create worktree
  2. Manually delete directory
  3. Attempt spawn → succeeds with auto-recovery

## Recovery Flow
```
git worktree add fails with "already registered"
  ↓
[WARN] Worktree already registered after cleanup, pruning all stale worktrees
  ↓
git worktree prune --verbose
  ↓
Retry: git worktree add
  ↓
[INFO] Successfully created worktree after prune recovery
```

## Impact
- **User experience**: No more manual `git worktree prune` required
- **Reliability**: Agent spawning succeeds even after interrupted cleanups
- **Debugging**: Clear log messages for troubleshooting

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added design docs describing relay improvements for worktree recovery and WebSocket log redaction.

* **New Features**
  * Automatic recovery from stale Git worktree entries with a prune-and-retry flow.
  * WebSocket log redaction that records a sanitized summary (message type and size) instead of full message content to avoid exposing PII or credentials.

* **Tests**
  * Plans for unit and integration tests covering recovery, redaction, edge cases, and security verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->